### PR TITLE
Add basic Selenium scraper project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # disputekznruscrape
-disputekznruscrape
+
+Simple Maven project demonstrating how to scrape pages of the site
+`https://dispute.kzn.ru` using Selenium in headless mode.
+
+## Build
+
+```
+mvn package
+```
+
+## Run
+
+By default the program downloads the text of disputes with id from 1 to 3
+and saves them to `dispute-<id>.txt`. You can specify a different upper
+id as the first argument.
+
+```
+java -cp target/disputescraper-1.0-SNAPSHOT.jar com.example.App 5
+```
+
+This will create files `dispute-1.txt` ... `dispute-5.txt` in the working
+directory.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>disputescraper</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.3.2</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -1,0 +1,40 @@
+package com.example;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.chrome.ChromeDriver;
+import io.github.bonigarcia.wdm.WebDriverManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+
+public class App {
+    public static void main(String[] args) throws IOException {
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless=new");
+        options.addArguments("--disable-gpu");
+
+        WebDriver driver = new ChromeDriver(options);
+        try {
+            int maxId = 3;
+            if (args.length > 0) {
+                try {
+                    maxId = Integer.parseInt(args[0]);
+                } catch (NumberFormatException ignored) {}
+            }
+            for (int id = 1; id <= maxId; id++) {
+                driver.get("https://dispute.kzn.ru/disputes/" + id);
+                WebElement body = driver.findElement(By.tagName("body"));
+                String text = body.getText();
+                Files.writeString(Path.of("dispute-" + id + ".txt"), text, StandardCharsets.UTF_8);
+            }
+        } finally {
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Maven config with Selenium/WebDriverManager dependencies
- implement headless Chrome scraper saving discussion texts
- document build and run instructions

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68492b71a6c8832aa4bc5c8a55c0a3b5