### PR TITLE
Document Maven download

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ Simple Maven project demonstrating how to scrape pages of the site
 
 ## Build
 
+Make sure Maven is installed. On Debian-based systems run:
+
+```
+sudo apt-get update && sudo apt-get install -y maven
+```
+
+If `apt-get` is not available you can manually download Maven from [Maven
+Central](https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/),
+unpack the archive and add the `bin` directory to your `PATH`.
+
 ```
 mvn package
 ```
@@ -21,3 +31,17 @@ java -cp target/disputescraper-1.0-SNAPSHOT.jar com.example.App 5
 
 This will create files `dispute-1.txt` ... `dispute-5.txt` in the working
 directory.
+
+## Troubleshooting
+
+If you encounter a `SessionNotCreatedException` mentioning that the current
+Chrome browser version does not match the downloaded ChromeDriver, clean the
+cached driver and let WebDriverManager download the correct one:
+
+```java
+WebDriverManager.chromedriver().clearDriverCache().setup();
+```
+
+Alternatively make sure the installed Chrome browser and the driver versions
+match (e.g. update Chrome or specify a driver version using
+`WebDriverManager.chromedriver().browserVersion("<major>").setup();`).

--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -14,7 +14,8 @@ import java.nio.charset.StandardCharsets;
 
 public class App {
     public static void main(String[] args) throws IOException {
-        WebDriverManager.chromedriver().setup();
+        // Download a fresh ChromeDriver in case a mismatched version is cached
+        WebDriverManager.chromedriver().clearDriverCache().setup();
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless=new");
         options.addArguments("--disable-gpu");


### PR DESCRIPTION
## Summary
- explain how to download Maven manually if apt-get isn't available
- refresh ChromeDriver cache during setup

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496fbe9874832aaeabb1fa21b23ca9