### PR TITLE
Enable JavaScript in HtmlUnit driver

### DIFF
--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -68,7 +68,8 @@ public class App {
             }
             driver = new ChromeDriver(options);
         } else {
-            HtmlUnitDriver hud = new HtmlUnitDriver(false);
+            HtmlUnitDriver hud = new HtmlUnitDriver(true);
+            hud.getWebClient().getOptions().setThrowExceptionOnScriptError(false);
             if (proxy != null) {
                 hud.setProxySettings(proxy);
             }
@@ -83,6 +84,9 @@ public class App {
             }
             for (int id = 1; id <= maxId; id++) {
                 driver.get("https://dispute.kzn.ru/disputes/" + id);
+                if (driver instanceof HtmlUnitDriver) {
+                    ((HtmlUnitDriver) driver).getWebClient().waitForBackgroundJavaScript(5000);
+                }
                 WebElement body = driver.findElement(By.tagName("body"));
                 String text = body.getText();
                 Files.writeString(Path.of("dispute-" + id + ".txt"), text, StandardCharsets.UTF_8);

--- a/src/test/java/com/example/AppTest.java
+++ b/src/test/java/com/example/AppTest.java
@@ -12,7 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class AppTest {
     @Test
     void pageTitleShouldBePresent() {
-        HtmlUnitDriver driver = new HtmlUnitDriver(false);
+        HtmlUnitDriver driver = new HtmlUnitDriver(true);
+        driver.getWebClient().getOptions().setThrowExceptionOnScriptError(false);
         String proxyUrl = System.getenv("HTTP_PROXY");
         if (proxyUrl == null || proxyUrl.isEmpty()) {
             proxyUrl = System.getenv("http_proxy");
@@ -33,6 +34,7 @@ public class AppTest {
         }
         try {
             driver.get("https://dispute.kzn.ru/disputes/1");
+            driver.getWebClient().waitForBackgroundJavaScript(5000);
             assertEquals("ИС ОО", driver.getTitle());
         } finally {
             driver.quit();


### PR DESCRIPTION
## Summary
- enable JavaScript when using HtmlUnitDriver
- wait for background scripts after each page load
- handle script errors in HtmlUnit
- update tests accordingly

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6849f8003900832ab4c6060f25aa0bfd