### PR TITLE
Improve page loading recovery

### DIFF
--- a/src/main/java/com/example/App.java
+++ b/src/main/java/com/example/App.java
@@ -135,10 +135,13 @@ public class App {
 
                 int attempts = 0;
                 while ("Идет загрузка".equals(t1) && "Это может занять некоторое время".equals(t2)) {
-                    if (attempts++ > 120) {
-                        break;
-                    }
-                    if (driver instanceof HtmlUnitDriver) {
+                    if (attempts++ >= 12) { // ~1 minute passed
+                        driver.get("https://dispute.kzn.ru/disputes/" + id);
+                        attempts = 0;
+                        if (driver instanceof HtmlUnitDriver) {
+                            ((HtmlUnitDriver) driver).getWebClient().waitForBackgroundJavaScript(5000);
+                        }
+                    } else if (driver instanceof HtmlUnitDriver) {
                         ((HtmlUnitDriver) driver).getWebClient().waitForBackgroundJavaScript(5000);
                     } else {
                         try {


### PR DESCRIPTION
## Summary
- refresh when page sits on the loading screen too long

## Testing
- `mvn -e test`
- `mvn -q exec:java -Dexec.mainClass=com.example.App -Dexec.args="16"`

------
https://chatgpt.com/codex/tasks/task_e_684a07823d0c832a9702bf8f561d90bd